### PR TITLE
Normalizing query names on cache lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ BIN := $(shell basename $$PWD)
 # Where to push the docker image.
 REGISTRY ?= quay.io/oriedge
 
+# Tag 
+TAG ?= latest
+
 # Image URL to use all building/pushing image targets
 IMG ?= $(REGISTRY)/$(BIN)
 
@@ -17,7 +20,7 @@ down:
 	tilt down
 
 nuke: 
-	kind delete cluster --name kind
+	-./test/teardown-kind-with-registry.sh &>/dev/null
 
 build:
 	CGO_ENABLED=0 go build cmd/coredns.go
@@ -31,4 +34,7 @@ clean:
 	rm -f coredns
 
 image: 
-	docker build . -t ${IMG}
+	docker build . -t ${IMG}:${TAG}
+
+release:
+	docker push ${IMG}:${TAG}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Test queries can be sent to the exposed CoreDNS service like this:
 $ ip=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')
 $ dig @$ip -p 32553 myservicea.foo.org +short
 172.18.0.2
-$ dig @$ip -p 32553 test.default +short
+$ dig @$ip -p 32553 test.default.foo.org +short
 192.168.1.241
 ```
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -5,7 +5,7 @@ IMG = 'localhost:5000/coredns'
 def binary():
     return "CGO_ENABLED=0  GOOS=linux GOATCH=amd64 GO111MODULE=on go build cmd/coredns.go"
 
-local_resource('recompile', binary(), deps=['cmd', 'gateway.go', 'kubernetes.go', 'setup.go'])
+local_resource('recompile', binary(), deps=['cmd', 'gateway.go', 'kubernetes.go', 'setup.go', 'apex.go'])
 
 docker_build_with_restart(IMG, '.', 
     dockerfile='tilt.Dockerfile', 

--- a/examples/install-clusterwide.yml
+++ b/examples/install-clusterwide.yml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: excoredns
+  name: external-dns
   namespace: kube-system
 spec:
   selector:

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -127,6 +128,20 @@ var tests = []test.Case{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	// Existing Ingress with a mix of lower and upper case letters
+	{
+		Qname: "dOmAiN.eXamPLe.cOm.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("domain.example.com.	5	IN	A	192.0.0.1"),
+		},
+	},
+	// Existing Service with a mix of lower and upper case letters
+	{
+		Qname: "svC1.Ns1.exAmplE.Com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.ns1.example.com.	5	IN	A	192.0.1.1"),
+		},
+	},
 }
 
 var testServiceIndexes = map[string][]net.IP{
@@ -137,7 +152,7 @@ var testServiceIndexes = map[string][]net.IP{
 
 func testServiceLookup(keys []string) (results []net.IP) {
 	for _, key := range keys {
-		results = append(results, testServiceIndexes[key]...)
+		results = append(results, testServiceIndexes[strings.ToLower(key)]...)
 	}
 	return results
 }
@@ -150,7 +165,7 @@ var testIngressIndexes = map[string][]net.IP{
 
 func testIngressLookup(keys []string) (results []net.IP) {
 	for _, key := range keys {
-		results = append(results, testIngressIndexes[key]...)
+		results = append(results, testIngressIndexes[strings.ToLower(key)]...)
 	}
 	return results
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net"
+	"strings"
 
 	core "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
@@ -169,7 +170,7 @@ func lookupServiceIndex(ctrl cache.SharedIndexInformer) func([]string) []net.IP 
 	return func(indexKeys []string) (result []net.IP) {
 		var objs []interface{}
 		for _, key := range indexKeys {
-			obj, _ := ctrl.GetIndexer().ByIndex(serviceHostnameIndex, key)
+			obj, _ := ctrl.GetIndexer().ByIndex(serviceHostnameIndex, strings.ToLower(key))
 			objs = append(objs, obj...)
 		}
 		log.Debugf("Found %d matching Service objects", len(objs))
@@ -186,7 +187,7 @@ func lookupIngressIndex(ctrl cache.SharedIndexInformer) func([]string) []net.IP 
 	return func(indexKeys []string) (result []net.IP) {
 		var objs []interface{}
 		for _, key := range indexKeys {
-			obj, _ := ctrl.GetIndexer().ByIndex(ingressHostnameIndex, key)
+			obj, _ := ctrl.GetIndexer().ByIndex(ingressHostnameIndex, strings.ToLower(key))
 			objs = append(objs, obj...)
 		}
 		log.Debugf("Found %d matching Ingress objects", len(objs))

--- a/test/kind-with-registry.sh
+++ b/test/kind-with-registry.sh
@@ -56,9 +56,17 @@ containerdConfigPatches:
     endpoint = ["http://${reg_host}:${reg_port}"]
 EOF
 
-for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-  kubectl annotate node "${node}" tilt.dev/registry=localhost:${reg_port};
-done
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
 
 if [ "${kind_network}" != "bridge" ]; then
   containers=$(docker network inspect ${kind_network} -f "{{range .Containers}}{{.Name}} {{end}}")

--- a/test/kubernetes.yaml
+++ b/test/kubernetes.yaml
@@ -17,7 +17,7 @@ data:
         errors
         log
         ready
-        k8s_gateway
+        k8s_gateway foo.org
         forward . /etc/resolv.conf
         cache 30
         loop
@@ -65,7 +65,7 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: excoredns
+  name: external-dns
   namespace: kube-system
 spec:
   selector:

--- a/test/teardown-kind-with-registry.sh
+++ b/test/teardown-kind-with-registry.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Adapted from:
+# https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh
+#
+# Copyright 2020 The Kubernetes Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+kind_version=$(kind version)
+kind_network='kind'
+reg_name='kind-registry'
+reg_port='5000'
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" == 'true' ]; then
+  cid="$(docker inspect -f '{{.ID}}' "${reg_name}")"
+  echo "> Stopping and deleting Kind Registry container..."
+  docker stop $cid >/dev/null
+  docker rm $cid >/dev/null
+fi
+
+echo "> Deleting Kind cluster..."
+kind delete cluster --name=$KIND_CLUSTER_NAME


### PR DESCRIPTION
Until now, the lookup was performed in the client-go's cache
using query name as it was received. This worked fine for all
normal queries but broked when queries contained uppercase letters.

One notable example of what got broked was Let's Encrypt. Their
DNS resolver would lookup the target domain name using a mix of
lower and uppwer case letters, which would result in a cache miss
and would fail with NXDOMAIN for the target domain.

This change converts all cache lookup keys to lower case.